### PR TITLE
Update helmfile.yaml for kuberhealthy version

### DIFF
--- a/helmfiles/kuberhealthy/helmfile.yaml
+++ b/helmfiles/kuberhealthy/helmfile.yaml
@@ -11,7 +11,7 @@ repositories:
   url: https://jenkins-x-charts.github.io/repo
 releases:
 - chart: kuberhealthy/kuberhealthy
-  version: "64"
+  version: "92"
   name: kuberhealthy
   values:
   - ../../versionStream/charts/kuberhealthy/kuberhealthy/values.yaml.gotmpl


### PR DESCRIPTION
The version of kuberhealthy can't properly install on any Kubernetes clusters where apiextensions.k8s.io/v1beta1 is no longer supported and instead needs apiextensions.k8s.io/v1. An update to version 92 should fix this.