### PR TITLE
fix: remove unused value / incorrect comment

### DIFF
--- a/jx-global-values.yaml
+++ b/jx-global-values.yaml
@@ -6,8 +6,3 @@ jx:
 
   # whether to create a Release CRD when installing charts with Release CRDs included
   releaseCRD: true
-
-  # these variables are used by 'jx gitops variables' to default environment variables
-  # into the .jx/variables.sh file which can be overriden on a pre repository basis
-  # or during a pipeline by writing to the '.jx/variables.sh' file
-  pipelineVariables: {}


### PR DESCRIPTION
I have found no reference to this value being used and no issue regarding the lack of functionality.
There are a couple of other mechanisms to expose environment variables to pipelines, so I say this can just be removed.